### PR TITLE
touch_default: numbers.cfg: fix overlapping of other touch buttons with numbers

### DIFF
--- a/touch_default/numbers.cfg
+++ b/touch_default/numbers.cfg
@@ -1,5 +1,6 @@
+touch_setclientonly "1"
 touch_hide show_numbers
-alias _numbers_clean "touch_removebutton _numbers_*;touch_show show_numbers;unalias _numbers_clean"
+alias _numbers_clean "touch_removebutton _numbers_*;touch_show show_numbers;touch_setclientonly 0;unalias _numbers_clean"
 touch_addbutton "_numbers_slot1" "touch_default/key_1" "slot1" 0.020000 0.845443 0.100000 0.980713 255 255 255 255 6 1
 touch_addbutton "_numbers_slot2" "touch_default/key_2" "slot2" 0.100000 0.845443 0.180000 0.980713 255 255 255 255 6 1
 touch_addbutton "_numbers_slot3" "touch_default/key_3" "slot3" 0.180000 0.845443 0.260000 0.980713 255 255 255 255 6 1


### PR DESCRIPTION
Due to the overlapping touch buttons, they are pressed simultaneously.